### PR TITLE
Allow multiple `should` conditions

### DIFF
--- a/src/FastNorth/Validator/Definition/Field.php
+++ b/src/FastNorth/Validator/Definition/Field.php
@@ -55,6 +55,8 @@ class Field implements FieldInterface
             'validator' => $constraint,
             'when'      => $when
         ];
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
The `should` method was missing its return statement.