### PR TITLE
allow validation of object or array with the same syntax

### DIFF
--- a/src/FastNorth/Validator/Validator.php
+++ b/src/FastNorth/Validator/Validator.php
@@ -87,6 +87,10 @@ class Validator implements ValidatorInterface
             throw new \RuntimeException('There is no field data to access, call validate() first');
         }
 
+        if (is_array($this->data)) {
+            $field = "[$field]";
+        }
+
         return $this->getPropertyAccessor()->getValue($this->data, $field);
     }
 


### PR DESCRIPTION
Not an elegant fix, but it avoids having to do a bunch of type checks and string manipulation in the validators.