### PR TITLE
Adding interpolation of constraint failure messages

### DIFF
--- a/src/FastNorth/Validator/Constraint/AbstractConstraint.php
+++ b/src/FastNorth/Validator/Constraint/AbstractConstraint.php
@@ -91,18 +91,28 @@ abstract class AbstractConstraint implements ConstraintInterface
     }
 
     /**
+     * Get all options
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
      * Fail validation.
      *
      * @param string|string[] $messages identifiers of the messages (keys)
      *
      * @return Validation
      */
-    protected function fail($messages)
+    protected function fail($messages, array $interpolate = [])
     {
         $fullMessages = [];
 
         foreach ((array) $messages as $key) {
-            $fullMessages[$key] = $this->getMessage($key);
+            $fullMessages[$key] = self::interpolate($this->getMessage($key), $interpolate);
         }
 
         return new Validation(false, $fullMessages);
@@ -117,4 +127,24 @@ abstract class AbstractConstraint implements ConstraintInterface
     {
         return new Validation(true);
     }
+
+    /**
+     * Interpolate a string using `{{ foo }}` placeholders
+     *
+     * @param string $string
+     * @param array $variables
+     */
+    protected static function interpolate($string, array $variables = [])
+    {
+        foreach($variables as $key => $value) {
+            $string = preg_replace(
+                sprintf('/\{\{\s*%s\s*\}\}/', $key),
+                $value,
+                $string
+            );
+        }
+
+        return $string;
+    }
 }
+

--- a/src/FastNorth/Validator/Constraint/StringLength.php
+++ b/src/FastNorth/Validator/Constraint/StringLength.php
@@ -37,7 +37,7 @@ class StringLength extends AbstractConstraint
     {
         return [
             self::TOO_SHORT => 'The value you have provided is shorter than the required {{ min }} characters',
-            self::TOO_LONG  => 'The value you have provided is longer than the maximum {{ min }} characters'
+            self::TOO_LONG  => 'The value you have provided is longer than the maximum {{ max }} characters'
         ];
     }
 

--- a/src/FastNorth/Validator/Constraint/StringLength.php
+++ b/src/FastNorth/Validator/Constraint/StringLength.php
@@ -19,12 +19,12 @@ class StringLength extends AbstractConstraint
     {
         $min = $this->getOption('min');
         if ($min >= 0 && strlen($value) < $min) {
-            return $this->fail(self::TOO_SHORT);
+            return $this->fail(self::TOO_SHORT, $this->getOptions());
         }
 
         $max = $this->getOption('max');
         if ($max >= 0 && strlen($value) > $max) {
-            return $this->fail(self::TOO_LONG);
+            return $this->fail(self::TOO_LONG, $this->getOptions());
         }
 
         return $this->pass();

--- a/tests/Unit/Constraint/StringLengthTest.php
+++ b/tests/Unit/Constraint/StringLengthTest.php
@@ -12,15 +12,28 @@ use FastNorth\Validator\Constraint;
 class StringLengthTest extends \PHPUnit_Framework_TestCase
 {
     /** @test */
-    public function itOutputsInterpolatedMessage()
+    public function itOutputsInterpolatedMessageWhenTooShort()
     {
         $constraint = new Constraint\StringLength(['min' => 5, 'max' => 25]);
         $validation = $constraint->validate('foo');
         $messages = $validation->getMessages();
-        var_dump($messages);
+        $this->assertFalse($validation->passes());
         $this->assertEquals(
             'The value you have provided is shorter than the required 5 characters',
             $messages[Constraint\StringLength::TOO_SHORT]
+        );
+    }
+
+    /** @test */
+    public function itOutputsInterpolatedMessageWhenTooLong()
+    {
+        $constraint = new Constraint\StringLength(['min' => 3, 'max' => 5]);
+        $validation = $constraint->validate('foobarbaz');
+        $messages = $validation->getMessages();
+        $this->assertFalse($validation->passes());
+        $this->assertEquals(
+            'The value you have provided is longer than the maximum 5 characters',
+            $messages[Constraint\StringLength::TOO_LONG]
         );
     }
 }

--- a/tests/Unit/Constraint/StringLengthTest.php
+++ b/tests/Unit/Constraint/StringLengthTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\Constraint;
+
+use FastNorth\Validator\Constraint;
+
+/**
+ * StringLengthTest
+ *
+ * Tess st
+ */
+class StringLengthTest extends \PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function itOutputsInterpolatedMessage()
+    {
+        $constraint = new Constraint\StringLength(['min' => 5, 'max' => 25]);
+        $validation = $constraint->validate('foo');
+        $messages = $validation->getMessages();
+        var_dump($messages);
+        $this->assertEquals(
+            'The value you have provided is shorter than the required 5 characters',
+            $messages[Constraint\StringLength::TOO_SHORT]
+        );
+    }
+}

--- a/tests/Unit/Validator/ValidatorTest.php
+++ b/tests/Unit/Validator/ValidatorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Unit\Validator;
+namespace Tests\Unit\Validator;
 
 use FastNorth\Validator\Validator;
 use FastNorth\Validator\Definition;


### PR DESCRIPTION
Adding support for the interpolation of failure messages through `$this->fail()` in the `AbstractConstraint`. Basis regex interpolation takes an array of variables and expands all `{{ foo }}` placeholders.

This fixes #4.