### PR TITLE
Add a constraint to validate a date/time string

### DIFF
--- a/src/FastNorth/Validator/Constraint/DateTimeString.php
+++ b/src/FastNorth/Validator/Constraint/DateTimeString.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace FastNorth\Validator\Constraint;
+
+/**
+ * DateTimeString
+ *
+ * Must be a valid date and time string
+ */
+class DateTimeString extends AbstractConstraint
+{
+    const INCORRECT_VALUE = 'invalid';
+    const EMPTY_VALUE = 'missing';
+
+    /**
+     * @inheritDoc
+     */
+    public function validate($value, $context = null)
+    {
+        if (empty($value)) {
+            return $this->fail(self::EMPTY_VALUE);
+        }
+
+        if (!is_date($value)) {
+            // is this string valid?
+            return $this->fail(self::INCORRECT_VALUE);
+        }
+
+        $timeStamp = strtotime($value);
+        if (!checkdate(date('m', $timeStamp), date('d', $timeStamp), date('Y', $timeStamp))) {
+            // does this string represent an actual date?
+            return $this->fail(self::INCORRECT_VALUE);
+        }
+
+        return $this->pass();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultMessages()
+    {
+        return [
+            self::EMPTY_VALUE => 'This field should not be empty',
+            self::INCORRECT_VALUE => 'This field is not a valid date time string'
+        ];
+    }
+}


### PR DESCRIPTION
This adds a validation constraint for a date/time string.

- the value should not be empty
- the value should be a valid date/time string with `is_date`
- the value should be a valid date with `checkdate` i.e. a date like `2015-02-29 00:00:00` would pass the `is_date` check however 2015 was not a leap year so there was no feb. 29. `checkdate` will return an error for this

