### PR TITLE
Don't use is_date for date/time string validation

### DIFF
--- a/src/FastNorth/Validator/Constraint/DateTimeString.php
+++ b/src/FastNorth/Validator/Constraint/DateTimeString.php
@@ -21,7 +21,7 @@ class DateTimeString extends AbstractConstraint
             return $this->fail(self::EMPTY_VALUE);
         }
 
-        if (!is_date($value)) {
+        if (!strtotime($value)) {
             // is this string valid?
             return $this->fail(self::INCORRECT_VALUE);
         }

--- a/src/FastNorth/Validator/Constraint/DateTimeString.php
+++ b/src/FastNorth/Validator/Constraint/DateTimeString.php
@@ -21,7 +21,7 @@ class DateTimeString extends AbstractConstraint
             return $this->fail(self::EMPTY_VALUE);
         }
 
-        if (!strtotime($value)) {
+        if (strtotime($value) === false) {
             // is this string valid?
             return $this->fail(self::INCORRECT_VALUE);
         }


### PR DESCRIPTION
This updates the DateTimeString validation constring to use strtotime to check for valid date/time string as is_date is not a built in PHP function