### PR TITLE
Allow 0 Values for Comparison Traits

### DIFF
--- a/src/FastNorth/Validator/Constraint/Between.php
+++ b/src/FastNorth/Validator/Constraint/Between.php
@@ -17,7 +17,7 @@ class Between extends AbstractConstraint
      */
     public function validate($value, $context = null)
     {
-        if (empty($value)) {
+        if (is_null($value)) {
             return $this->fail(self::EMPTY_VALUE);
         }
 

--- a/src/FastNorth/Validator/Constraint/GreaterThan.php
+++ b/src/FastNorth/Validator/Constraint/GreaterThan.php
@@ -17,7 +17,7 @@ class GreaterThan extends AbstractConstraint
      */
     public function validate($value, $context = null)
     {
-        if (empty($value)) {
+        if (is_null($value)) {
             return $this->fail(self::EMPTY_VALUE);
         }
 

--- a/src/FastNorth/Validator/Constraint/GreaterThanOrEqual.php
+++ b/src/FastNorth/Validator/Constraint/GreaterThanOrEqual.php
@@ -17,7 +17,7 @@ class GreaterThanOrEqual extends AbstractConstraint
      */
     public function validate($value, $context = null)
     {
-        if (empty($value)) {
+        if (is_null($value)) {
             return $this->fail(self::EMPTY_VALUE);
         }
 

--- a/src/FastNorth/Validator/Constraint/LessThan.php
+++ b/src/FastNorth/Validator/Constraint/LessThan.php
@@ -17,7 +17,7 @@ class LessThan extends AbstractConstraint
      */
     public function validate($value, $context = null)
     {
-        if (empty($value)) {
+        if (is_null($value)) {
             return $this->fail(self::EMPTY_VALUE);
         }
 

--- a/src/FastNorth/Validator/Constraint/LessThanOrEqual.php
+++ b/src/FastNorth/Validator/Constraint/LessThanOrEqual.php
@@ -17,7 +17,7 @@ class LessThanOrEqual extends AbstractConstraint
      */
     public function validate($value, $context = null)
     {
-        if (empty($value)) {
+        if (is_null($value)) {
             return $this->fail(self::EMPTY_VALUE);
         }
 


### PR DESCRIPTION
# Allow 0 Values for Comparison Traits

## Problem Description
Using `empty()` was preventing a value of 0 to be allowed for the constraints.

## Code Changes
* Use `is_null` to only prevent a `null` value