### PR TITLE
Allow multiple symfony/property-access versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "fastnorth/validator",
     "description": "FastNorth Validator",
     "require": {
-        "symfony/property-access": "~2.7.0"
+        "symfony/property-access": "~2.7|~3.2|~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8.0"


### PR DESCRIPTION
# Allow multiple symfony/property-access versions

Updates the required version to be `~2.7.0|~2.8|3.*|4.*`

https://github.com/fastnorth/RaceRoster/tree/symfony-upgrade